### PR TITLE
Optimize tokio Runtime usage in benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.29"
+version = "1.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c1599538de2394445747c8cf7935946e3cc27e9625f889d979bfb2aaf569362"
+checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
 dependencies = [
  "jobserver",
  "libc",
@@ -993,9 +993,9 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "instability"
-version = "0.3.7"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+checksum = "435d80800b936787d62688c927b6490e887c7ef5ff9ce922c6c6050fca75eb9a"
 dependencies = [
  "darling",
  "indoc",
@@ -1017,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "io-uring"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
 dependencies = [
  "bitflags 2.9.1",
  "cfg-if",
@@ -1156,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "360e552c93fa0e8152ab463bc4c4837fce76a225df11dfaeea66c313de5e61f7"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -1178,9 +1178,9 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litrs"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
+checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
 name = "lock_api"
@@ -1757,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.13"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -1827,9 +1827,9 @@ checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
@@ -1918,9 +1918,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -2244,9 +2244,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+checksum = "e06723639aaded957e5a80be250c1f82f274b9d23ebb4d94163668470623461c"
 dependencies = [
  "indexmap",
  "serde",
@@ -2473,6 +2473,7 @@ dependencies = [
  "dirs",
  "jemallocator",
  "mimalloc",
+ "once_cell",
  "proptest",
  "ratatui",
  "serde_json",
@@ -2523,7 +2524,7 @@ dependencies = [
  "serde",
  "tempfile",
  "tokio",
- "toml 0.9.2",
+ "toml 0.9.3",
  "tracing",
 ]
 
@@ -2803,7 +2804,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2824,10 +2825,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ ratatui = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+once_cell = "1.19"
 
 [dev-dependencies]
 dirs = { workspace = true }

--- a/benches/organizer_benchmark.rs
+++ b/benches/organizer_benchmark.rs
@@ -77,7 +77,6 @@ fn benchmark_organize_by_type(c: &mut Criterion) {
     group.finish();
 }
 
-
 fn benchmark_organize_modes(c: &mut Criterion) {
     let mut group = c.benchmark_group("FileOrganizer::organize_modes");
     group.sample_size(10);

--- a/benches/organizer_benchmark.rs
+++ b/benches/organizer_benchmark.rs
@@ -53,7 +53,7 @@ async fn run_organize(dest: &std::path::Path, files: Vec<Arc<MediaFile>>, settin
 
 fn benchmark_organize_by_type(c: &mut Criterion) {
     let mut group = c.benchmark_group("FileOrganizer::organize_by_type");
-    group.sample_size(10);
+    group.sample_size(30);
 
     for &file_count in &[100usize, 500, 1000] {
         group.bench_with_input(BenchmarkId::new("files", file_count), &file_count, |b, &file_count| {

--- a/benches/organizer_benchmark.rs
+++ b/benches/organizer_benchmark.rs
@@ -59,7 +59,7 @@ fn benchmark_organize_by_type(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("files", file_count), &file_count, |b, &file_count| {
             b.iter_batched(
                 || {
-                :    let temp_dir = TempDir::new().unwrap();
+                    let temp_dir = TempDir::new().unwrap(); // 🔧 Додано
                     let files = create_test_media_files(file_count);
                     let settings = Settings {
                         destination_folder: Some(temp_dir.path().to_path_buf()),
@@ -76,6 +76,7 @@ fn benchmark_organize_by_type(c: &mut Criterion) {
 
     group.finish();
 }
+
 
 fn benchmark_organize_modes(c: &mut Criterion) {
     let mut group = c.benchmark_group("FileOrganizer::organize_modes");

--- a/justfile
+++ b/justfile
@@ -26,4 +26,9 @@ lint-fix:
 test:
     @echo "\nRunning tests..."
     cargo nextest run --workspace 
-    @echo "Done running tests!\n"  
+    @echo "Done running tests!\n" 
+
+clippy:
+    echo "Running clippy checks..."
+    cargo clippy --all-targets --all-features -- -D warnings
+


### PR DESCRIPTION
## Summary

This PR optimizes the usage of `tokio::Runtime` in benchmark files by instantiating it only once and passing it into benchmark functions, instead of creating it for every test case.

## Why

- Reduces overhead of runtime creation
- Improves consistency and maintainability
- Cleaner code

Let me know if you'd prefer a different structure!
